### PR TITLE
Fix default global_nodejs_version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ nodebuild_version: "latest"
 nodenvvars_version: "latest"
 
 nodejs_versions: []
-global_nodejs_version:
+global_nodejs_version: ""
 
 plugins: []
 


### PR DESCRIPTION
To match ansible-role-python.

Otherwise, you may get:
```
object of type 'NoneType' has no len()
```